### PR TITLE
Cache public SSH keys in S3 bucket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,8 @@ The following configuration parameters can/should be passed via environment vari
     The SSH private key (can be encrypted with KMS).
 ``SSH_USER``
     The SSH username on remote servers (default: "granting-service").
+``USERSVC_CACHE_BUCKET``
+    Optional S3 bucket name to use for caching SSH public keys (to bridge potential downtimes of upstream HTTP service).
 ``USERSVC_SSH_PUBLIC_KEY_URL_TEMPLATE``
     URL template for the public SSH key endpoints ("{user}" will be replaced with the user's ID/username). Example: "https://users.example.org/employees/{user}/ssh"
 

--- a/generate-scm-source-json.sh
+++ b/generate-scm-source-json.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-REV=$(git rev-parse HEAD)
-URL=$(git config --get remote.origin.url)
-STATUS=$(git status --porcelain)
-if [ -n "$STATUS" ]; then
-    REV="$REV (locally modified)"
-fi
-# finally write hand-crafted JSON to scm-source.json
-echo '{"url": "git:'$URL'", "revision": "'$REV'", "author": "'$USER'", "status": "'$STATUS'"}' > scm-source.json

--- a/src/org/zalando/stups/even/pubkey_provider/usersvc.clj
+++ b/src/org/zalando/stups/even/pubkey_provider/usersvc.clj
@@ -4,19 +4,67 @@
     [clj-http.client :as client]
     [org.zalando.stups.friboo.system.oauth2 :as oauth2]
     [com.netflix.hystrix.core :refer [defcommand]]
-    [org.zalando.stups.friboo.config :as config])
-  (:import [java.util.regex Pattern]))
+    [org.zalando.stups.friboo.config :as config]
+    [clojure.java.io :as io]
+    [amazonica.aws.s3 :as s3])
+  (:import [java.util.regex Pattern]
+           [java.util UUID]
+           [com.amazonaws.services.s3.model AmazonS3Exception]))
 
 (defrecord Usersvc [config tokens])
 
 (def user-placeholder (Pattern/quote "{user}"))
 
-(defcommand get-public-key [name {:keys [config tokens] :as usersvc}]
-            "Get a user's public SSH key"
-            (let [template (config/require-config config :ssh-public-key-url-template)
-                  url (.replaceAll template user-placeholder name)]
-              (:body (client/get url
-                                 {:oauth-token (oauth2/access-token "user-service" tokens)}))))
+(defcommand get-public-key-from-service
+  "Get a user's public SSH key from HTTP service"
+  [name {:keys [config tokens] :as usersvc}]
+  (let [template (config/require-config config :ssh-public-key-url-template)
+        url (.replaceAll template user-placeholder name)]
+       (:body (client/get url
+                          {:oauth-token (oauth2/access-token "user-service" tokens)}))))
+
+(defn get-s3-key [name]
+  "Get S3 object key from public key name"
+  (str "public-keys/" name ".pub"))
+
+(defcommand get-public-key-from-s3
+  "Try to load SSH public key from S3 cache bucket"
+  [name {:keys [config] :as usersvc}]
+  (try
+    (let [bucket (config/require-config config :cache-bucket)
+          result (s3/get-object :bucket-name bucket
+                                :key (get-s3-key name))]
+         (slurp (:input-stream result)))
+  (catch AmazonS3Exception se
+         ; just return null if the S3 object does not exist
+         (when-not (= 404 (.getStatusCode se))
+                   (throw se)))))
+
+(defcommand store-public-key-on-s3
+  "Store SSH public key in S3 cache bucket"
+  [name public-key {:keys [config] :as usersvc}]
+  (let [bucket (config/require-config config :cache-bucket)
+        ^File tmp-file (io/file "/tmp" (str name ".tmp-" (UUID/randomUUID)))]
+       (spit tmp-file public-key)
+       (s3/put-object :bucket-name bucket
+                      :key (get-s3-key name)
+                      :file tmp-file)
+       (io/delete-file tmp-file true)))
+
+(defn get-public-key
+  "Get user's public SSH key, first try HTTP service, then S3 cache bucket"
+  [name {:keys [config] :as usersvc}]
+  (try
+    (let [public-key (get-public-key-from-service name usersvc)]
+         (when (:cache-bucket config)
+               (store-public-key-on-s3 name public-key usersvc))
+         public-key)
+    (catch Throwable ex
+      (if (:cache-bucket config)
+          (do
+              (log/error ex "Failed to get SSH public key from HTTP service, falling back to S3 cache bucket")
+              (get-public-key-from-s3 name usersvc))
+          (throw ex)))))
 
 (defn ^Usersvc new-usersvc [config]
   (log/info "Configuring User Service with" (config/mask config))


### PR DESCRIPTION
Always store user's public SSH key in S3 bucket on GET.
First try to get from User Service (HTTP endpoint), fallback to S3 bucket in case of any error.
