### PR TITLE
Fix write shell history

### DIFF
--- a/grant-ssh-access-forced-command.py
+++ b/grant-ssh-access-forced-command.py
@@ -236,7 +236,7 @@ def is_generated_by_us(keys_file):
 def kill_all_processes(user_name: str):
     '''try to write session before killing all processes'''
     subprocess.call(['sudo', 'killall', '-u', user_name, '-w'])
-    time.sleep(5)
+    time.sleep(2)
     subprocess.call(['sudo', 'killall', '-KILL', '-u', user_name, '-w'])
 
 

--- a/grant-ssh-access-forced-command.py
+++ b/grant-ssh-access-forced-command.py
@@ -33,6 +33,7 @@ import sys
 import syslog
 import tempfile
 import yaml
+import time
 
 from pathlib import Path
 
@@ -233,6 +234,9 @@ def is_generated_by_us(keys_file):
 
 
 def kill_all_processes(user_name: str):
+    '''try to write session before killing all processes'''
+    subprocess.call(['sudo', 'killall', '-u', user_name, '-w'])
+    time.sleep(5)
     subprocess.call(['sudo', 'killall', '-KILL', '-u', user_name, '-w'])
 
 

--- a/grant-ssh-access-forced-command.py
+++ b/grant-ssh-access-forced-command.py
@@ -235,7 +235,7 @@ def is_generated_by_us(keys_file):
 
 def kill_all_processes(user_name: str):
     '''try to write session before killing all processes'''
-    subprocess.call(['sudo', 'killall', '-u', user_name, '-w'])
+    subprocess.call(['sudo', 'killall', '-u', user_name])
     time.sleep(2)
     subprocess.call(['sudo', 'killall', '-KILL', '-u', user_name, '-w'])
 


### PR DESCRIPTION
As noticed in issue https://github.com/zalando-stups/taupage/issues/167 This proposal tries first to kill processes with sigterm and after 2 seconds with sigkill.

It is required, because SIGKILL prevents to first write the users shell history, which I would consider as a bug.
