### PR TITLE
use latest OpenJDK base image with MEM_TOTAL_KB support for Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-45
+FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
Use latest OpenJDK image supporting overwrite of `MEM_TOTAL_KB` for Kubernetes (https://github.com/zalando/docker-openjdk/pull/11).