### PR TITLE
Switch to compliant base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,10 @@ EXPOSE 8080
 
 VOLUME /tmp
 
-CMD java $JAVA_OPTS -jar /even.jar
+ENTRYPOINT ["java", \
+            "-XX:InitialRAMPercentage=80.0", \
+            "-XX:MinRAMPercentage=80.0", \
+            "-XX:MaxRAMPercentage=80.0", \
+            "-XX:+ExitOnOutOfMemoryError", \
+            "-jar", \
+            "even.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 
 MAINTAINER Zalando SE
 
@@ -9,5 +9,4 @@ EXPOSE 8080
 
 VOLUME /tmp
 
-CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar /even.jar
-
+CMD java $JAVA_OPTS -jar /even.jar

--- a/dev-resources/dockerfile.sshd
+++ b/dev-resources/dockerfile.sshd
@@ -1,9 +1,11 @@
 FROM ubuntu:latest
 
+ADD entrypoint.sh /entrypoint.sh
+
 RUN apt-get update && \
     apt-get install -y openssh-server && \
     mkdir /root/.ssh && \
     chmod 700 /root/.ssh && \
     mkdir /var/run/sshd
 EXPOSE 22
-ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e", "-p", "22", "-o", "PasswordAuthentication=no"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev-resources/entrypoint.sh
+++ b/dev-resources/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/env bash
+
+cp /authorized_keys /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+chown root:root /root/.ssh/authorized_keys
+
+exec "/usr/sbin/sshd" "-D" "-e" "-p" "22" "-o" "PasswordAuthentication=no"

--- a/test/org/zalando/stups/even/ssh_test.clj
+++ b/test/org/zalando/stups/even/ssh_test.clj
@@ -21,10 +21,11 @@
 (defn test-with-pubkey
   [pub-key-file]
   (let [image (-> (ImageFromDockerfile.)
-                (.withFileFromClasspath "Dockerfile", "dockerfile.sshd"))
+                (.withFileFromClasspath "Dockerfile", "dockerfile.sshd")
+                (.withFileFromClasspath "entrypoint.sh", "entrypoint.sh"))
         container (doto (GenericContainer. image)
                     (.addExposedPort (int 22))
-                    (.addFileSystemBind pub-key-file "/root/.ssh/authorized_keys" BindMode/READ_ONLY)
+                    (.addFileSystemBind pub-key-file "/authorized_keys" BindMode/READ_ONLY)
                     (.setWaitStrategy (-> (HostPortWaitStrategy.)
                                           (.withStartupTimeout (Duration/of 60 ChronoUnit/SECONDS))))
                     (.start))]


### PR DESCRIPTION
Switch to compliant base image and drop usage of `java-dynamic-memory-opts` which is no longer supported.