### PR TITLE
Add RDS cert to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM registry.opensource.zalan.do/library/openjdk-8:latest
+label maintainer="Zalando SE"
 
-MAINTAINER Zalando SE
+# add AWS RDS CA bundle
+RUN mkdir /tmp/rds-ca && \
+    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > /tmp/rds-ca/aws-rds-ca-bundle.pem
+# split the bundle into individual certs (prefixed with xx)
+# see http://blog.swwomm.com/2015/02/importing-new-rds-ca-certificate-into.html
+RUN cd /tmp/rds-ca && csplit -sz aws-rds-ca-bundle.pem '/-BEGIN CERTIFICATE-/' '{*}'
+RUN for CERT in /tmp/rds-ca/xx*; do mv $CERT /usr/local/share/ca-certificates/aws-rds-ca-$(basename $CERT).crt; done
+
+RUN update-ca-certificates
 
 COPY target/even.jar /
 COPY resources/api/even-api.yaml /zalando-apis/


### PR DESCRIPTION
Follow up to #71 

RDS certificates are no longer included in the base image so we have to add it ourselves.